### PR TITLE
test: pin wild-action to a fork to validate hardened download

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -113,4 +113,4 @@ runs:
 
     - name: Install Wild Linker
       if: inputs.enable-wild-linker == 'true'
-      uses: davidlattimore/wild-action@0.7.0
+      uses: Vaiz/wild-linker-action@fix/harden-wild-download

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -115,5 +115,4 @@ runs:
       if: inputs.enable-wild-linker == 'true'
       uses: Vaiz/wild-linker-action@fix/harden-wild-download
       with:
-        download-retries: "10"
-        download-retry-delay: "5"
+        download-retries: "6"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -114,3 +114,6 @@ runs:
     - name: Install Wild Linker
       if: inputs.enable-wild-linker == 'true'
       uses: Vaiz/wild-linker-action@fix/harden-wild-download
+      with:
+        download-retries: "10"
+        download-retry-delay: "5"


### PR DESCRIPTION
Temporary — will be reverted to wild-linker/action@<tag> once the upstream fix is merged and tagged.