### PR TITLE
ci: switch wild linker to wild-linker/action@0.8.0

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -113,4 +113,6 @@ runs:
 
     - name: Install Wild Linker
       if: inputs.enable-wild-linker == 'true'
-      uses: davidlattimore/wild-action@0.7.0
+      uses: wild-linker/action@0.8.0
+      with:
+        download-retries: "6"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -114,5 +114,3 @@ runs:
     - name: Install Wild Linker
       if: inputs.enable-wild-linker == 'true'
       uses: wild-linker/action@0.8.0
-      with:
-        download-retries: "6"


### PR DESCRIPTION
The action moved from davidlattimore/wild-action to the wild-linker org (see https://github.com/wild-linker/action).