### PR TITLE
test(cargo-heather): add unit tests for missed mutations

### DIFF
--- a/crates/cargo-heather/src/comment.rs
+++ b/crates/cargo-heather/src/comment.rs
@@ -166,3 +166,47 @@ impl CommentStyle {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inner_attribute_is_not_cargo_script() {
+        // `#![...]` is a Rust inner attribute, not a shebang.
+        assert!(!is_cargo_script("#![allow(unused)]\n---\n"));
+    }
+
+    #[test]
+    fn shebang_without_frontmatter_is_not_cargo_script() {
+        assert!(!is_cargo_script("#!/usr/bin/env cargo\nfn main() {}\n"));
+    }
+
+    #[test]
+    fn valid_cargo_script() {
+        assert!(is_cargo_script("#!/usr/bin/env cargo\n---\n"));
+    }
+
+    #[test]
+    fn doc_comment_is_not_header_comment() {
+        let style = CommentStyle::DoubleSlash;
+        // `///` is a doc comment, not a header comment.
+        assert!(!style.is_header_comment_line("///"));
+        assert!(!style.is_header_comment_line("/// doc"));
+    }
+
+    #[test]
+    fn inner_doc_comment_is_not_header_comment() {
+        let style = CommentStyle::DoubleSlash;
+        // `//!` is an inner doc comment, not a header comment.
+        assert!(!style.is_header_comment_line("//!"));
+        assert!(!style.is_header_comment_line("//! module doc"));
+    }
+
+    #[test]
+    fn regular_comment_is_header_comment() {
+        let style = CommentStyle::DoubleSlash;
+        assert!(style.is_header_comment_line("// Copyright"));
+        assert!(style.is_header_comment_line("//"));
+    }
+}

--- a/crates/cargo-heather/src/error.rs
+++ b/crates/cargo-heather/src/error.rs
@@ -74,3 +74,26 @@ impl std::error::Error for HeatherError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+
+    #[test]
+    fn file_read_error_exposes_source() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "gone");
+        let err = HeatherError::FileRead {
+            path: PathBuf::from("/tmp/missing"),
+            source: io_err,
+        };
+        let source = err.source().expect("FileRead should have a source");
+        assert!(source.to_string().contains("gone"));
+    }
+
+    #[test]
+    fn non_io_variants_have_no_source() {
+        let err = HeatherError::ConfigInvalid("bad".into());
+        assert!(err.source().is_none());
+    }
+}

--- a/crates/cargo-heather/src/license.rs
+++ b/crates/cargo-heather/src/license.rs
@@ -248,3 +248,24 @@ pub fn supported_licenses() -> Vec<&'static str> {
     ids.sort_unstable();
     ids
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn supported_licenses_contains_known_ids() {
+        let ids = supported_licenses();
+        assert!(!ids.is_empty());
+        assert!(ids.contains(&"MIT"));
+        assert!(ids.contains(&"Apache-2.0"));
+    }
+
+    #[test]
+    fn supported_licenses_is_sorted() {
+        let ids = supported_licenses();
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        assert_eq!(ids, sorted);
+    }
+}


### PR DESCRIPTION
Add unit tests to catch 7 mutations that were previously missed by cargo-mutants, causing nightly CI failures since 2026-05-15.

Tests added:
- comment.rs: is_cargo_script inner attribute rejection, missing frontmatter, valid script detection; is_header_comment_line doc comment exclusion (/// and //!)
- error.rs: HeatherError::source() returns io::Error for FileRead variant and None for others
- license.rs: supported_licenses() contains known IDs and returns sorted results

Fixes #27