### PR TITLE
refactor(cargo-heather): replace tracing with println

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,8 +88,6 @@ dependencies = [
  "serde",
  "tempfile",
  "toml",
- "tracing",
- "tracing-subscriber",
  "walkdir",
 ]
 
@@ -116,12 +114,6 @@ dependencies = [
  "serde_json",
  "thiserror",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -251,12 +243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,12 +307,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "predicates"
@@ -464,15 +444,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shared_child"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,15 +509,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,36 +545,6 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
-
-[[package]]
-name = "tracing"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
-dependencies = [
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
-dependencies = [
- "sharded-slab",
- "thread_local",
- "tracing-core",
-]
 
 [[package]]
 name = "typeid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,8 +85,6 @@ toml = { version = "1.1.2", default-features = false }
 tower = { version = "0.5.2", default-features = false }
 tower-layer = { version = "0.3.3", default-features = false }
 tower-service = { version = "0.3.3", default-features = false }
-tracing = { version = "0.1.41", default-features = false }
-tracing-subscriber = { version = "0.3.20", default-features = false }
 trait-variant = { version = "0.1.2", default-features = false }
 trybuild = { version = "1.0.114", default-features = false }
 typeid = { version = "1.0.3", default-features = false }

--- a/crates/cargo-heather/Cargo.toml
+++ b/crates/cargo-heather/Cargo.toml
@@ -31,8 +31,6 @@ clap = { workspace = true, features = ["derive", "std", "help", "usage", "error-
 ohno = { workspace = true, features = ["app-err"] }
 serde = { workspace = true, features = ["derive", "alloc"] }
 toml = { workspace = true, features = ["parse", "display", "serde"] }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["fmt"] }
 walkdir = { workspace = true }
 
 [dev-dependencies]

--- a/crates/cargo-heather/src/bin/cargo-heather/config.rs
+++ b/crates/cargo-heather/src/bin/cargo-heather/config.rs
@@ -12,7 +12,6 @@ use std::path::{Path, PathBuf};
 use cargo_heather::HeatherError;
 use cargo_heather::license;
 use serde::Deserialize;
-use tracing::info;
 
 /// The default configuration file name.
 pub(crate) const CONFIG_FILE_NAME: &str = ".cargo-heather.toml";
@@ -87,7 +86,7 @@ pub(crate) fn load_config(project_dir: &Path) -> Result<HeatherConfig, HeatherEr
     if cargo_toml_path.exists()
         && let Some(config) = try_load_from_cargo_toml(&cargo_toml_path)?
     {
-        info!("No {} found, using license from Cargo.toml.", CONFIG_FILE_NAME);
+        println!("No {CONFIG_FILE_NAME} found, using license from Cargo.toml.");
         return Ok(config);
     }
 

--- a/crates/cargo-heather/src/bin/cargo-heather/main.rs
+++ b/crates/cargo-heather/src/bin/cargo-heather/main.rs
@@ -10,18 +10,10 @@ mod scanner;
 
 use clap::Parser;
 use ohno::AppError;
-use tracing_subscriber::fmt::format::FmtSpan;
 
 use crate::cli::CargoCli;
 
 fn main() -> Result<(), AppError> {
-    tracing_subscriber::fmt()
-        .with_target(false)
-        .with_level(false)
-        .with_span_events(FmtSpan::NONE)
-        .without_time()
-        .init();
-
     let CargoCli::Heather(args) = CargoCli::parse();
     run::run(&args)
 }

--- a/crates/cargo-heather/src/bin/cargo-heather/run.rs
+++ b/crates/cargo-heather/src/bin/cargo-heather/run.rs
@@ -11,7 +11,6 @@ use std::path::{Path, PathBuf};
 
 use cargo_heather::{CheckResult, CommentStyle, FileKind, HeatherError};
 use ohno::AppError;
-use tracing::info;
 
 use crate::cli::HeatherArgs;
 use crate::config::{self, HeatherConfig};
@@ -24,11 +23,11 @@ pub(crate) fn run(args: &HeatherArgs) -> Result<(), AppError> {
     let files = scanner::find_source_files(&project_dir, Some(&config_path), &config);
 
     if files.is_empty() {
-        info!("No source files found in '{}'.", project_dir.display());
+        println!("No source files found in '{}'.", project_dir.display());
         return Ok(());
     }
 
-    info!("Checking {} file(s)...", files.len());
+    println!("Checking {} file(s)...", files.len());
 
     if args.fix {
         run_fix(&files, &config, &project_dir)?;
@@ -69,13 +68,13 @@ fn run_check(files: &[PathBuf], config: &HeatherConfig, project_dir: &Path) -> R
         match &result {
             CheckResult::Ok => {}
             CheckResult::Missing => {
-                info!("  MISSING header: {}", relative.display());
+                println!("  MISSING header: {}", relative.display());
                 failures += 1;
             }
             CheckResult::Mismatch { expected, actual } => {
-                info!("  MISMATCH header: {}", relative.display());
+                println!("  MISMATCH header: {}", relative.display());
                 for line in format_mismatch_details(expected, actual).lines() {
-                    info!("{line}");
+                    println!("{line}");
                 }
                 failures += 1;
             }
@@ -86,7 +85,7 @@ fn run_check(files: &[PathBuf], config: &HeatherConfig, project_dir: &Path) -> R
         ohno::bail!(HeatherError::ValidationFailed(failures));
     }
 
-    info!("All {checked} file(s) have correct license headers.");
+    println!("All {checked} file(s) have correct license headers.");
     Ok(())
 }
 
@@ -111,7 +110,7 @@ fn run_fix(files: &[PathBuf], config: &HeatherConfig, project_dir: &Path) -> Res
                     path: path.clone(),
                     source: e,
                 })?;
-                info!("  Fixed (added header): {}", relative.display());
+                println!("  Fixed (added header): {}", relative.display());
                 fixed_count += 1;
             }
             CheckResult::Mismatch { .. } => {
@@ -119,15 +118,15 @@ fn run_fix(files: &[PathBuf], config: &HeatherConfig, project_dir: &Path) -> Res
                     path: path.clone(),
                     source: e,
                 })?;
-                info!("  Fixed (replaced header): {}", relative.display());
+                println!("  Fixed (replaced header): {}", relative.display());
                 fixed_count += 1;
             }
         }
     }
 
     match fixed_count {
-        0 => info!("All files already have correct headers."),
-        n => info!("Fixed {n} file(s)."),
+        0 => println!("All files already have correct headers."),
+        n => println!("Fixed {n} file(s)."),
     }
 
     Ok(fixed_count)


### PR DESCRIPTION
cargo-heather used tracing only for user-facing `info!()` output with all structured-logging features disabled (no levels, no targets, no timestamps, no spans). Replace with plain `println!()` and drop `tracing` + `tracing-subscriber` from both the crate and the workspace.

This removes 9 transitive crates (tracing, tracing-core, tracing-subscriber, sharded-slab, thread_local, lazy_static, pin-project-lite, once_cell, cfg-if) from the dependency tree