### PR TITLE
fix(cargo-heather): warn on unresolvable exclude entries and document exclude key

### DIFF
--- a/crates/cargo-heather/README.md
+++ b/crates/cargo-heather/README.md
@@ -39,7 +39,7 @@ All rights reserved.
 #### Excluding Files and Directories
 
 Use the `exclude` key to skip specific files or directories from scanning.
-Entries are **literal paths relative to the project root** (the directory
+Entries are **literal paths**. Relative paths are resolved against the project root (the directory
 passed to `--project-dir`, or the current directory by default). Glob patterns
 and wildcards are **not** supported.
 

--- a/crates/cargo-heather/README.md
+++ b/crates/cargo-heather/README.md
@@ -36,6 +36,24 @@ All rights reserved.
 """
 ```
 
+#### Excluding Files and Directories
+
+Use the `exclude` key to skip specific files or directories from scanning.
+Entries are **literal paths relative to the project root** (the directory
+passed to `--project-dir`, or the current directory by default). Glob patterns
+and wildcards are **not** supported.
+
+```toml
+exclude = ["vendor", "generated/bindings.rs"]
+```
+
+A directory entry excludes its entire subtree recursively. Entries that do not
+exist on disk produce a warning and are ignored.
+
+> **Note:** `target/`, `.git/`, `.github/`, `.vscode/`, `.idea/`,
+> `node_modules/`, and other dot-prefixed directories are already skipped
+> automatically.
+
 ### Usage
 
 ```bash

--- a/crates/cargo-heather/src/bin/cargo-heather/scanner.rs
+++ b/crates/cargo-heather/src/bin/cargo-heather/scanner.rs
@@ -23,8 +23,14 @@ pub(crate) fn find_source_files(project_dir: &Path, exclude_path: Option<&Path>,
     let exclude_list: Vec<PathBuf> = config
         .exclude
         .iter()
-        .map(|rel| project_dir.join(rel))
-        .filter_map(|p| std::fs::canonicalize(&p).ok())
+        .filter_map(|rel| {
+            let full = project_dir.join(rel);
+            std::fs::canonicalize(&full)
+                .inspect_err(|err| {
+                    println!("  Warning: exclude entry '{rel}' could not be resolved and will be ignored: {err}");
+                })
+                .ok()
+        })
         .collect();
 
     let mut files: Vec<PathBuf> = WalkDir::new(project_dir)

--- a/crates/cargo-heather/tests/cli.rs
+++ b/crates/cargo-heather/tests/cli.rs
@@ -361,6 +361,29 @@ fn scanner_exclude_list_filters_directory_subtree() {
 }
 
 #[test]
+fn scanner_warns_on_unresolvable_exclude_entry() {
+    let dir = TempDir::new().unwrap();
+    let p = dir.path();
+    // Mix a valid exclude ("vendor") with an invalid one ("nonexistent_dir").
+    let cfg = format!("{CONFIG_MIT}exclude = [\"vendor\", \"nonexistent_dir\"]\n");
+    write(&p.join(".cargo-heather.toml"), &cfg);
+    write(&p.join("a.rs"), &format!("{HEADER_TEXT}\nfn a() {{}}\n"));
+    write(&p.join("vendor/lib.rs"), "fn lib() {}\n"); // would fail if scanned
+
+    let out = run_heather(p, &[]);
+    let stderr = stderr_of(&out);
+    // Valid exclude still works — vendor/lib.rs is excluded, only a.rs is checked.
+    assert!(out.status.success(), "valid excludes must still work: {stderr}");
+    assert!(stderr.contains("Checking 1 file(s)"), "{stderr}");
+    // Warning is emitted for the unresolvable entry.
+    assert!(
+        stderr.contains("Warning: exclude entry 'nonexistent_dir'"),
+        "should warn about unresolvable exclude: {stderr}"
+    );
+    assert!(stderr.contains("will be ignored"), "warning must mention it is ignored: {stderr}");
+}
+
+#[test]
 fn scanner_includes_legacy_hash_comment_file_types() {
     let dir = TempDir::new().unwrap();
     let p = dir.path();


### PR DESCRIPTION
# Summary
Previously, exclude entries in `.cargo-heather.toml` that could not be resolved by `std::fs::canonicalize` (e.g. glob patterns, typos, or paths to non-existent files) were silently dropped. This made it appear as though the tool was ignoring the user's configuration.

# Changes
`scanner.rs` - Emit a warning for each unresolvable exclude entry. The scan still proceeds (warning, not error).
`README.md` - Document the exclude config key: literal paths, relative to project root, directory entries exclude the whole subtree.
`cli.rs` - Add test with mixed valid + invalid excludes verifying the warning is emitted and valid excludes still work.

# Note on glob support
Glob/wildcard pattern support in exclude is a separate feature request, not a bug fix. This PR addresses only the silent-failure usability issue and the documentation gap.