### PR TITLE
feat(cargo-heather): recognize .psd1 and .psm1 as PowerShell files

### DIFF
--- a/crates/cargo-heather/README.md
+++ b/crates/cargo-heather/README.md
@@ -15,7 +15,9 @@
 
 ## cargo-heather
 
-A cargo sub-command to validate license headers in Rust (`.rs`) and TOML (`.toml`) source files.
+A cargo sub-command to validate license headers in Rust (`.rs`), TOML (`.toml`),
+PowerShell (`.ps1`, `.psd1`, `.psm1`), Just (`justfile`, `*.just`), and env
+(`constants.env`) source files.
 
 ### Setup
 
@@ -57,7 +59,7 @@ exist on disk produce a warning and are ignored.
 ### Usage
 
 ```bash
-# Check all .rs and .toml files for correct license headers
+# Check all supported source files for correct license headers
 cargo heather
 
 # Automatically fix files by adding/replacing headers
@@ -116,8 +118,13 @@ Fixed 2 file(s).
 ### How it works
 
 1. **Config loading** — Reads `.cargo-heather.toml` from the project root and resolves the expected header text (from SPDX identifier or custom text).
-1. **File scanning** — Walks the project directory to find all `.rs` and `.toml` files, skipping `target/`, hidden directories, and the config file itself.
-1. **Header validation** — Extracts the first comment block from each file (`//` for Rust, `#` for TOML) and compares it to the expected header. Reports missing or mismatched headers.
+1. **File scanning** — Walks the project directory to find all supported source
+   files (`.rs`, `.toml`, `.ps1`, `.psd1`, `.psm1`, `.just`, `justfile`,
+   `constants.env`), skipping `target/`, hidden directories, and the config
+   file itself.
+1. **Header validation** — Extracts the first comment block from each file
+   (`//` for Rust, `#` for the rest) and compares it to the expected header.
+   Reports missing or mismatched headers.
 1. **Fix mode** — When `--fix` is passed, automatically prepends the correct header to files that are missing it, or replaces incorrect headers.
 
 

--- a/crates/cargo-heather/README.md
+++ b/crates/cargo-heather/README.md
@@ -122,9 +122,13 @@ Fixed 2 file(s).
    files (`.rs`, `.toml`, `.ps1`, `.psd1`, `.psm1`, `.just`, `justfile`,
    `constants.env`), skipping `target/`, hidden directories, and the config
    file itself.
-1. **Header validation** — Extracts the first comment block from each file
-   (`//` for Rust, `#` for the rest) and compares it to the expected header.
-   Reports missing or mismatched headers.
+1. **Header validation** — Extracts the header comment block from each file
+   in a way appropriate to the file kind: a `//` block at the top for Rust
+   sources, a `#` block at the top for TOML / Just / `constants.env`, a `#`
+   block after an optional `#!` shebang for PowerShell, and a `#` block
+   inside the `---` frontmatter for Rust cargo-scripts. The extracted block
+   is then compared to the expected header. Reports missing or mismatched
+   headers.
 1. **Fix mode** — When `--fix` is passed, automatically prepends the correct header to files that are missing it, or replaces incorrect headers.
 
 

--- a/crates/cargo-heather/README.md
+++ b/crates/cargo-heather/README.md
@@ -118,18 +118,21 @@ Fixed 2 file(s).
 ### How it works
 
 1. **Config loading** — Reads `.cargo-heather.toml` from the project root and resolves the expected header text (from SPDX identifier or custom text).
-1. **File scanning** — Walks the project directory to find all supported source
-   files (`.rs`, `.toml`, `.ps1`, `.psd1`, `.psm1`, `.just`, `justfile`,
-   `constants.env`), skipping `target/`, hidden directories, and the config
-   file itself.
-1. **Header validation** — Extracts the header comment block from each file
-   in a way appropriate to the file kind: a `//` block at the top for Rust
-   sources, a `#` block at the top for TOML / Just / `constants.env`, a `#`
-   block after an optional `#!` shebang for PowerShell, and a `#` block
-   inside the `---` frontmatter for Rust cargo-scripts. The extracted block
-   is then compared to the expected header. Reports missing or mismatched
-   headers.
+1. **File scanning** — Walks the project directory for supported source files (see [Supported file kinds](#supported-file-kinds) below), skipping `target/`, hidden directories, and the config file itself.
+1. **Header validation** — Extracts the header comment block from each file (placement depends on the file kind) and compares it to the expected header. Reports missing or mismatched headers.
 1. **Fix mode** — When `--fix` is passed, automatically prepends the correct header to files that are missing it, or replaces incorrect headers.
+
+### Supported file kinds
+
+| File                          | Comment style | Header placement                                   |
+| ----------------------------- | ------------- | -------------------------------------------------- |
+| `.rs` (regular)               | `//`          | Top of file                                        |
+| `.rs` (cargo-script)          | `#`           | Inside the `---` frontmatter                       |
+| `.toml`                       | `#`           | Top of file                                        |
+| `.ps1`, `.psd1`, `.psm1`      | `#`           | Top of file, or after a leading `#!` shebang       |
+| `*.just`, `justfile`          | `#`           | Top of file                                        |
+| `constants.env`               | `#`           | Top of file                                        |
+
 
 
 <hr/>

--- a/crates/cargo-heather/src/comment.rs
+++ b/crates/cargo-heather/src/comment.rs
@@ -15,7 +15,8 @@ pub enum FileKind {
     Rust,
     /// A TOML file (`.toml`). Header uses `#` at the top.
     Toml,
-    /// A `PowerShell` script (`.ps1`). Header uses `#` at the top.
+    /// A `PowerShell` script (`.ps1`) or data/module file (`.psd1`, `.psm1`).
+    /// Header uses `#` at the top.
     PowerShell,
     /// A Just recipe file (`*.just` or `justfile`). Header uses `#` at the top.
     Just,
@@ -50,7 +51,9 @@ impl FileKind {
                 }
             }
             ext if ext.eq_ignore_ascii_case("toml") => Some(Self::Toml),
-            ext if ext.eq_ignore_ascii_case("ps1") => Some(Self::PowerShell),
+            ext if ext.eq_ignore_ascii_case("ps1") || ext.eq_ignore_ascii_case("psd1") || ext.eq_ignore_ascii_case("psm1") => {
+                Some(Self::PowerShell)
+            }
             ext if ext.eq_ignore_ascii_case("just") => Some(Self::Just),
             _ => None,
         }
@@ -208,5 +211,39 @@ mod tests {
         let style = CommentStyle::DoubleSlash;
         assert!(style.is_header_comment_line("// Copyright"));
         assert!(style.is_header_comment_line("//"));
+    }
+
+    #[test]
+    fn detect_powershell_script_by_ps1_extension() {
+        assert_eq!(FileKind::detect(Path::new("build.ps1"), None), Some(FileKind::PowerShell));
+        // Case-insensitive — Windows paths often surface as `.PS1`.
+        assert_eq!(FileKind::detect(Path::new("BUILD.PS1"), None), Some(FileKind::PowerShell));
+    }
+
+    #[test]
+    fn detect_powershell_data_file_by_psd1_extension() {
+        // `.psd1` is plain PowerShell data syntax with the same `#`
+        // line-comment style as `.ps1`; should be classified as
+        // PowerShell so `cargo-heather` can validate / fix headers.
+        assert_eq!(FileKind::detect(Path::new("Module.psd1"), None), Some(FileKind::PowerShell));
+        assert_eq!(FileKind::detect(Path::new("scenario.psd1"), None), Some(FileKind::PowerShell));
+        assert_eq!(FileKind::detect(Path::new("MODULE.PSD1"), None), Some(FileKind::PowerShell));
+    }
+
+    #[test]
+    fn detect_powershell_module_by_psm1_extension() {
+        // `.psm1` is a PowerShell module file; same `#` comment style as `.ps1`.
+        assert_eq!(FileKind::detect(Path::new("Module.psm1"), None), Some(FileKind::PowerShell));
+        assert_eq!(FileKind::detect(Path::new("MODULE.PSM1"), None), Some(FileKind::PowerShell));
+    }
+
+    #[test]
+    fn detect_returns_none_for_unsupported_extensions() {
+        assert_eq!(FileKind::detect(Path::new("notes.txt"), None), None);
+        assert_eq!(FileKind::detect(Path::new("README.md"), None), None);
+        // Confirm we did not start matching on a substring (e.g. `ps`, `psd`).
+        assert_eq!(FileKind::detect(Path::new("a.ps"), None), None);
+        assert_eq!(FileKind::detect(Path::new("a.psd"), None), None);
+        assert_eq!(FileKind::detect(Path::new("a.psm"), None), None);
     }
 }

--- a/crates/cargo-heather/src/comment.rs
+++ b/crates/cargo-heather/src/comment.rs
@@ -16,7 +16,8 @@ pub enum FileKind {
     /// A TOML file (`.toml`). Header uses `#` at the top.
     Toml,
     /// A `PowerShell` script (`.ps1`) or data/module file (`.psd1`, `.psm1`).
-    /// Header uses `#` at the top.
+    /// Header uses `#`, placed at the top of the file or immediately after a
+    /// leading `#!` shebang line if one is present.
     PowerShell,
     /// A Just recipe file (`*.just` or `justfile`). Header uses `#` at the top.
     Just,

--- a/crates/cargo-heather/src/lib.rs
+++ b/crates/cargo-heather/src/lib.rs
@@ -42,7 +42,8 @@
 //!
 //! - [`FileKind::Rust`] — regular Rust source (`//` comments).
 //! - [`FileKind::Toml`] — TOML files (`#` comments).
-//! - [`FileKind::PowerShell`] — `PowerShell` scripts (`#` comments).
+//! - [`FileKind::PowerShell`] — `PowerShell` scripts (`.ps1`), data
+//!   files (`.psd1`), and module files (`.psm1`) (all use `#` comments).
 //! - [`FileKind::Just`] — Just recipes (`#` comments).
 //! - [`FileKind::Env`] — `constants.env` files (`#` comments).
 //! - [`FileKind::CargoScript`] — Rust script with shebang + `---`

--- a/crates/cargo-heather/tests/cli.rs
+++ b/crates/cargo-heather/tests/cli.rs
@@ -392,6 +392,12 @@ fn scanner_includes_legacy_hash_comment_file_types() {
         &p.join("build.ps1"),
         &format!("#!/usr/bin/env pwsh\n{HEADER_TEXT_HASH}\nWrite-Host 'ok'\n"),
     );
+    // `.psd1` is plain PowerShell data syntax (used for module manifests
+    // and config-style hashtables) and `.psm1` is a PowerShell module file;
+    // both use the same `#` line-comment syntax as `.ps1` and must be
+    // scanned alongside it.
+    write(&p.join("Settings.psd1"), &format!("{HEADER_TEXT_HASH}\n@{{ Name = 'Settings' }}\n"));
+    write(&p.join("Module.psm1"), &format!("{HEADER_TEXT_HASH}\nfunction Get-Foo {{ }}\n"));
     write(&p.join("recipes.just"), &format!("{HEADER_TEXT_HASH}\nbuild:\n    cargo build\n"));
     write(&p.join("justfile"), &format!("{HEADER_TEXT_HASH}\ntest:\n    cargo test\n"));
     write(&p.join("constants.env"), &format!("{HEADER_TEXT_HASH}\nRUST_LATEST=1.88.0\n"));
@@ -402,9 +408,9 @@ fn scanner_includes_legacy_hash_comment_file_types() {
         out.status.success(),
         "legacy hash-comment files should be checked and pass: {stderr}"
     );
-    assert!(stderr.contains("Checking 4 file(s)"), "{stderr}");
+    assert!(stderr.contains("Checking 6 file(s)"), "{stderr}");
     assert!(
-        stderr.contains("All 4 file(s) have correct license headers."),
+        stderr.contains("All 6 file(s) have correct license headers."),
         "summary missing for legacy hash-comment files: {stderr}"
     );
 }
@@ -420,6 +426,35 @@ fn scanner_reports_missing_header_in_legacy_hash_comment_file_type() {
     let stderr = stderr_of(&out);
     assert!(!out.status.success(), "missing PowerShell header should fail: {stderr}");
     assert!(stderr.contains("MISSING header: build.ps1"), "missing log absent: {stderr}");
+}
+
+#[test]
+fn scanner_reports_missing_header_in_powershell_data_file() {
+    // Regression guard: `.psd1` must be classified as PowerShell so a
+    // missing header is reported (rather than the file being silently
+    // skipped, which was the pre-fix behaviour).
+    let dir = TempDir::new().unwrap();
+    let p = dir.path();
+    write(&p.join(".cargo-heather.toml"), CONFIG_MIT);
+    write(&p.join("Settings.psd1"), "@{ Name = 'Settings' }\n");
+
+    let out = run_heather(p, &[]);
+    let stderr = stderr_of(&out);
+    assert!(!out.status.success(), "missing .psd1 header should fail: {stderr}");
+    assert!(stderr.contains("MISSING header: Settings.psd1"), "missing log absent: {stderr}");
+}
+
+#[test]
+fn scanner_reports_missing_header_in_powershell_module_file() {
+    let dir = TempDir::new().unwrap();
+    let p = dir.path();
+    write(&p.join(".cargo-heather.toml"), CONFIG_MIT);
+    write(&p.join("Module.psm1"), "function Get-Foo { }\n");
+
+    let out = run_heather(p, &[]);
+    let stderr = stderr_of(&out);
+    assert!(!out.status.success(), "missing .psm1 header should fail: {stderr}");
+    assert!(stderr.contains("MISSING header: Module.psm1"), "missing log absent: {stderr}");
 }
 
 #[test]


### PR DESCRIPTION
Recognize `.psd1` (PowerShell data) and `.psm1` (PowerShell module) files as PowerShell sources in `FileKind::detect` so the scanner checks/fixes their license headers instead of silently skipping them.

## Motivation

`.psd1` and `.psm1` use the same `#` line-comment syntax as `.ps1` scripts and routinely appear alongside them — module manifests (`MyMod.psd1`), data files driving PowerShell-based tooling (e.g. Pester scenario fixtures), and module implementations (`MyMod.psm1`). Pre-fix, `FileKind::detect` matched only `ps1` so these files were silently dropped during scanning. Running `cargo heather` against a directory containing `.psd1` fixtures with no header reports `All N file(s) have correct license headers` even though those fixtures were never inspected.

This was observed in microsoft/oxidizer#436 (a new Pester scenario suite landed ~25 `.psd1` fixtures without license headers and CI did not catch it).

## Change

- `FileKind::detect` in `crates/cargo-heather/src/comment.rs`: extend the PowerShell match arm to additionally accept `psd1` and `psm1` (case-insensitive, matching existing arms).
- Doc comments on `FileKind::PowerShell` and `lib.rs` module docs updated to enumerate the supported PowerShell extensions.
- `crates/cargo-heather/README.md` brought up to date — it previously claimed only `.rs` and `.toml` were supported (pre-dated even `.ps1`, `.just`, and `constants.env`).

The downstream scanner in `src/bin/cargo-heather/scanner.rs` filters via `CommentStyle::from_path(path).is_some()`, which delegates to `FileKind::detect`; comment-style mapping for `FileKind::PowerShell` was already `CommentStyle::Hash`. So extending `detect` is sufficient — no scanner or fix-mode changes needed.

## Tests

- 4 unit tests added in `comment::tests` exercising `FileKind::detect` for `.ps1`, `.psd1`, `.psm1` (mixed case), plus a negative test asserting we did not start matching on substrings like `.ps`, `.psd`, `.psm`.
- `scanner_includes_legacy_hash_comment_file_types` (integration) now includes `Settings.psd1` and `Module.psm1` fixtures and asserts `Checking 6 file(s)`.
- 2 new integration tests (`scanner_reports_missing_header_in_powershell_data_file` and `…_module_file`) lock in the regression: a missing header on a `.psd1` / `.psm1` is detected and reported, not silently skipped.

`cargo test -p cargo-heather` passes (25 unit + 19 integration + 5 ms-mit + 3 toml + 3 script + 7 etc.; no failures). `cargo clippy -p cargo-heather --all-targets -- -D warnings` clean. `just format-check` and the workspace `cargo heather` run both clean.

## Backwards compatibility

Purely additive. Existing `.ps1`, `.toml`, `.rs`, `justfile`, `constants.env` behaviour is unchanged. Users with `.psd1` / `.psm1` files in their tree that previously had no header will see new `MISSING header` diagnostics on their next run — that is the desired behaviour (the previous silent skip was the defect).
