### PR TITLE
ci: upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -94,23 +94,23 @@ runs:
 
     - name: Start Sccache
       if: inputs.enable-sccache == 'true' && !(runner.os == 'Windows' && runner.arch == 'ARM64')
-      uses: mozilla-actions/sccache-action@v0.0.9
+      uses: mozilla-actions/sccache-action@v0.0.10
       with:
         version: ${{ env.SCCACHE_VERSION }}
 
     - name: Install Rust
       if: inputs.rust-toolchain != ''
-      uses: actions-rust-lang/setup-rust-toolchain@v1.15.2
+      uses: actions-rust-lang/setup-rust-toolchain@v1.16.1
       with:
         toolchain: ${{ steps.expand.outputs.toolchain }}
         components: ${{ inputs.rust-components }}
 
     - name: Install Cargo Tools
       if: inputs.cargo-tools != ''
-      uses: taiki-e/install-action@v2.65.1
+      uses: taiki-e/install-action@v2.81.8
       with:
         tool: ${{ steps.expand.outputs.cargo_tools }}
 
     - name: Install Wild Linker
       if: inputs.enable-wild-linker == 'true'
-      uses: wild-linker/action@0.8.0
+      uses: wild-linker/action@0.9.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@v6.0.3
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@v4.36.2
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -96,6 +96,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@v4.36.2
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -54,7 +54,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -94,7 +94,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 1
       - name: Setup
@@ -114,7 +114,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
       - name: Setup
@@ -180,7 +180,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -206,7 +206,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
       - name: Setup
@@ -235,7 +235,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -250,7 +250,7 @@ jobs:
       - name: Generate Coverage (no-default-features)
         run: cargo +${{ env.RUST_NIGHTLY }} llvm-cov --no-default-features --workspace --lcov --output-path lcov-no-def.info
       - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov-all.info,lcov-no-def.info
@@ -285,7 +285,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -301,7 +301,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
       - name: Setup
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       should_skip: ${{ steps.check.outputs.should_skip }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
     steps:
       # prep
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
       - name: Setup
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/publish-gh-release.yml
+++ b/.github/workflows/publish-gh-release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@v6.0.3
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@nightly


### PR DESCRIPTION
Upgrades all GitHub Actions used in this repository to the latest available versions.

| Action | From | To |
|---|---|---|
| `actions/checkout` | v6.0.2 | **v6.0.3** |
| `github/codeql-action/init` | v4 | **v4.36.2** |
| `github/codeql-action/analyze` | v4 | **v4.36.2** |
| `codecov/codecov-action` | v6.0.0 | **v7.0.0** |
| `mozilla-actions/sccache-action` | v0.0.9 | **v0.0.10** |
| `actions-rust-lang/setup-rust-toolchain` | v1.15.2 | **v1.16.1** |
| `taiki-e/install-action` | v2.65.1 | **v2.81.8** |
| `wild-linker/action` | 0.8.0 | **0.9.0** |

The `github/codeql-action` references are now patch-pinned (`v4.36.2`) to match the patch-level pinning used elsewhere in this repository.

Already at the latest available version (no change):
- `marocchino/sticky-pull-request-comment@v3.0.4`
- `amannn/action-semantic-pull-request@v6.1.1`

Left intentionally unchanged:
- `dtolnay/rust-toolchain@nightly` — channel pointer, not a version pin.

Notes on `codecov/codecov-action@v7.0.0`: the v7 release notes show only an internal release-signing key migration; there are no consumer-facing breaking changes.