### PR TITLE
chore(cargo-heather): publish v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-heather"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ homepage = "https://github.com/microsoft/ox-tools"
 
 [workspace.dependencies]
 # local dependencies
-cargo-heather = { path = "crates/cargo-heather", default-features = false, version = "0.2.1" }
+cargo-heather = { path = "crates/cargo-heather", default-features = false, version = "0.3.0" }
 
 # external dependencies
 ahash = { version = "0.8", default-features = false }

--- a/crates/cargo-heather/CHANGELOG.md
+++ b/crates/cargo-heather/CHANGELOG.md
@@ -1,4 +1,25 @@
 # Changelog
+## [0.3.0] - 2026-06-11
+
+- ✨ Features
+
+  - recognize .psd1 and .psm1 as PowerShell files ([#38](https://github.com/microsoft/ox-tools/pull/38))
+
+- 🐛 Bug Fixes
+
+  - warn on unresolvable exclude entries and document exclude key ([#37](https://github.com/microsoft/ox-tools/pull/37))
+  - preserve CRLF line endings in --fix mode ([#31](https://github.com/microsoft/ox-tools/pull/31))
+
+- ♻️ Code Refactoring
+
+  - replace tracing with println ([#34](https://github.com/microsoft/ox-tools/pull/34))
+
+## [0.2.1] - 2026-05-22
+
+- 🐛 Bug Fixes
+
+  - don't overwrite comments in ps1 files ([#29](https://github.com/microsoft/ox-tools/pull/29))
+
 ## [0.2.0] - 2026-05-15
 
 - ✨ Features

--- a/crates/cargo-heather/Cargo.toml
+++ b/crates/cargo-heather/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "cargo-heather"
 description = " A cargo subcommand to validate license headers in Rust, TOML, PowerShell, Just, and env source files"
-version = "0.2.1"
+version = "0.3.0"
 readme = "README.md"
 keywords = ["oxidizer", "cargo", "subcommand", "license", "cli"]
 categories = ["command-line-utilities", "development-tools::cargo-plugins"]

--- a/crates/cargo-heather/Cargo.toml
+++ b/crates/cargo-heather/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cargo-heather"
-description = " A cargo subcommand to validate license headers in Rust, TOML, PowerShell, Just, and env source files"
+description = "A cargo subcommand to validate license headers in Rust, TOML, PowerShell, Just, and env source files"
 version = "0.3.0"
 readme = "README.md"
 keywords = ["oxidizer", "cargo", "subcommand", "license", "cli"]


### PR DESCRIPTION
- ✨ Features

  - recognize .psd1 and .psm1 as PowerShell files ([#38](https://github.com/microsoft/ox-tools/pull/38))

- 🐛 Bug Fixes

  - warn on unresolvable exclude entries and document exclude key ([#37](https://github.com/microsoft/ox-tools/pull/37))
  - preserve CRLF line endings in --fix mode ([#31](https://github.com/microsoft/ox-tools/pull/31))

- ♻️ Code Refactoring

  - replace tracing with println ([#34](https://github.com/microsoft/ox-tools/pull/34))