### PR TITLE
fix(cargo-anvil): fall back to --workspace on empty impact env vars

### DIFF
--- a/.anvil.lock
+++ b/.anvil.lock
@@ -1,7 +1,7 @@
 version = 1
 tool = "anvil"
 tool_version = "0.1.0"
-catalog_checksum = "sha256:1abe6661c04a48acb601d3e52be8dfff3b65540c4ebfa89ce25ed0498b462aa7"
+catalog_checksum = "sha256:ef31c1c9998ccf08d75b194bc8030ee25a2a64de8fa263382d6de88bd7af2ba8"
 
 [[file]]
 path = ".github/actions/anvil-impact/action.yml"
@@ -61,7 +61,7 @@ checksum = "sha256:a45359b92a6d851fc39bfa1c03aeb489b544ae37a1cea390dbbf860b2def8
 
 [[file]]
 path = "justfiles/anvil/checks.just"
-checksum = "sha256:dd551ba9d70716674817ed0ac6639035c4cd468fa62e7811abfbf672703225af"
+checksum = "sha256:ca4b1c49b74f75eb1657a6d0b648140a9f1e305991f21c4b2e88e11ff3a3522a"
 
 [[file]]
 path = "justfiles/anvil/groups.just"

--- a/crates/cargo-anvil/templates/justfiles/anvil/checks.just
+++ b/crates/cargo-anvil/templates/justfiles/anvil/checks.just
@@ -30,24 +30,30 @@
 #     here. Scheduled-exhaustive recipes (mutants-full) are also unscoped
 #     by design.
 #
-# Local invocation (no impact wiring): all three env vars are unset
-# (recipes use the `?? "--workspace"` null-coalescing fallback below);
-# modified-tier recipes simply skip the splice and run their
+# Local invocation (no impact wiring): all three env vars are unset or
+# empty (recipes fall back to "--workspace" via the truthiness check
+# below); modified-tier recipes simply skip the splice and run their
 # workspace-wide tool; affected/required-tier recipes splat
-# "--workspace" when the env var is unset.
+# "--workspace" when the env var is empty or unset.
 #
 # Preparation contract: when a recipe reaches the cargo call, the
 # env var is one of:
 #
-#   * unset                       - local run; the recipe substitutes
-#                                    "--workspace" via `?? "--workspace"`
+#   * unset or ""                 - local run, or a cloud workflow (e.g.
+#                                    scheduled) that leaves the tier
+#                                    unscoped; the recipe substitutes
+#                                    "--workspace". An empty string is
+#                                    NOT $null, so we test truthiness
+#                                    rather than `?? "--workspace"`
+#                                    (which would only catch $null and
+#                                    splat an empty arg cargo rejects).
 #   * "--package A --package B"   - emitted by the cloud-workflow impact step when
 #                                    the tier has members
 #   * "--skip"                    - emitted by the cloud-workflow impact step when
 #                                    the tier is empty (recipe exits 0)
 #
 # This lets the simple recipes splat the var directly with
-#   & cargo X @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) ...
+#   & cargo X @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) ...
 # and reduces the per-recipe boilerplate to a single one-line skip
 # guard plus the cargo invocation.
 #
@@ -61,9 +67,9 @@
 # installer. We chose pwsh over bash because just's shebang dispatch
 # requires `cygpath` on Windows (only on PATH from inside Git Bash),
 # while [script("pwsh")] works from plain PowerShell with no PATH
-# augmentation. The `??` null-coalescing operator used in the splat
-# requires pwsh 7+, which is the floor we already require via
-# _anvil-require pwsh.
+# augmentation. We require pwsh 7+ (enforced via _anvil-require pwsh)
+# for consistent semantics of the array-splat splice and the modern
+# operators used across these recipes.
 #
 # Single-command recipes (cargo deny check, cargo audit) are plain
 # just recipes that inherit the adopter's default shell — they're
@@ -99,7 +105,7 @@ anvil-fmt: anvil-fmt-validate-prereqs
 anvil-clippy: anvil-clippy-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo clippy @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --all-targets --all-features --locked "--" '-D' 'warnings'
+    & cargo clippy @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --all-targets --all-features --locked "--" '-D' 'warnings'
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Modified tier.
@@ -149,7 +155,7 @@ anvil-doc-build: anvil-doc-build-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_REQUIRED -eq '--skip') { exit 0 }
     $env:RUSTDOCFLAGS = '-D warnings'
-    & cargo doc @(-split ($env:ANVIL_INCLUDE_REQUIRED ?? "--workspace")) --all-features --no-deps
+    & cargo doc @(if ($env:ANVIL_INCLUDE_REQUIRED) { -split $env:ANVIL_INCLUDE_REQUIRED } else { '--workspace' }) --all-features --no-deps
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Modified tier.
@@ -333,7 +339,7 @@ anvil-audit: anvil-audit-validate-prereqs
 anvil-udeps: anvil-udeps-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_REQUIRED -eq '--skip') { exit 0 }
-    & cargo '+{{ rust_nightly }}' udeps @(-split ($env:ANVIL_INCLUDE_REQUIRED ?? "--workspace")) --all-features
+    & cargo '+{{ rust_nightly }}' udeps @(if ($env:ANVIL_INCLUDE_REQUIRED) { -split $env:ANVIL_INCLUDE_REQUIRED } else { '--workspace' }) --all-features
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Affected tier (compares published API of changed crates against the
@@ -663,7 +669,7 @@ anvil-llvm-cov: anvil-llvm-cov-validate-prereqs
 anvil-doc-test: anvil-doc-test-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    $pkg = @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace"))
+    $pkg = @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' })
     & cargo test --doc @pkg --all-features --locked
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     & cargo test --doc @pkg --locked
@@ -674,7 +680,7 @@ anvil-doc-test: anvil-doc-test-validate-prereqs
 anvil-examples: anvil-examples-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo build @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --examples --all-features --locked
+    & cargo build @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --examples --all-features --locked
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # === pr-mutants member ====================================================
@@ -749,7 +755,7 @@ anvil-miri: anvil-miri-validate-prereqs
     # empty test runs as success for miri only. Other nextest-using
     # recipes (llvm-cov) keep exit-4 as a failure because zero tests
     # there almost always indicates a config mistake.
-    & cargo '+{{ rust_nightly }}' miri nextest run --no-tests=pass @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace"))
+    & cargo '+{{ rust_nightly }}' miri nextest run --no-tests=pass @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' })
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Stricter miri profiles. Each runs miri over the full workspace
@@ -808,7 +814,7 @@ anvil-miri-race-coverage: anvil-miri-race-coverage-validate-prereqs
 anvil-careful: anvil-careful-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo '+{{ rust_nightly }}' careful test @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --all-features --locked
+    & cargo '+{{ rust_nightly }}' careful test @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --all-features --locked
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Affected tier. `loom` is a permutation-based concurrency model
@@ -904,7 +910,7 @@ anvil-mutants-full: anvil-mutants-full-validate-prereqs
 anvil-cargo-hack: anvil-cargo-hack-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_REQUIRED -eq '--skip') { exit 0 }
-    & cargo hack @(-split ($env:ANVIL_INCLUDE_REQUIRED ?? "--workspace")) --feature-powerset --depth 2 check
+    & cargo hack @(if ($env:ANVIL_INCLUDE_REQUIRED) { -split $env:ANVIL_INCLUDE_REQUIRED } else { '--workspace' }) --feature-powerset --depth 2 check
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Affected tier.
@@ -912,7 +918,7 @@ anvil-cargo-hack: anvil-cargo-hack-validate-prereqs
 anvil-bench: anvil-bench-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo bench @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --all-features --no-run
+    & cargo bench @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --all-features --no-run
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 

--- a/crates/cargo-anvil/tests/snapshots/snapshots__ado_backend.snap
+++ b/crates/cargo-anvil/tests/snapshots/snapshots__ado_backend.snap
@@ -1219,24 +1219,30 @@ unknown-git = "deny"
 #     here. Scheduled-exhaustive recipes (mutants-full) are also unscoped
 #     by design.
 #
-# Local invocation (no impact wiring): all three env vars are unset
-# (recipes use the `?? "--workspace"` null-coalescing fallback below);
-# modified-tier recipes simply skip the splice and run their
+# Local invocation (no impact wiring): all three env vars are unset or
+# empty (recipes fall back to "--workspace" via the truthiness check
+# below); modified-tier recipes simply skip the splice and run their
 # workspace-wide tool; affected/required-tier recipes splat
-# "--workspace" when the env var is unset.
+# "--workspace" when the env var is empty or unset.
 #
 # Preparation contract: when a recipe reaches the cargo call, the
 # env var is one of:
 #
-#   * unset                       - local run; the recipe substitutes
-#                                    "--workspace" via `?? "--workspace"`
+#   * unset or ""                 - local run, or a cloud workflow (e.g.
+#                                    scheduled) that leaves the tier
+#                                    unscoped; the recipe substitutes
+#                                    "--workspace". An empty string is
+#                                    NOT $null, so we test truthiness
+#                                    rather than `?? "--workspace"`
+#                                    (which would only catch $null and
+#                                    splat an empty arg cargo rejects).
 #   * "--package A --package B"   - emitted by the cloud-workflow impact step when
 #                                    the tier has members
 #   * "--skip"                    - emitted by the cloud-workflow impact step when
 #                                    the tier is empty (recipe exits 0)
 #
 # This lets the simple recipes splat the var directly with
-#   & cargo X @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) ...
+#   & cargo X @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) ...
 # and reduces the per-recipe boilerplate to a single one-line skip
 # guard plus the cargo invocation.
 #
@@ -1250,9 +1256,9 @@ unknown-git = "deny"
 # installer. We chose pwsh over bash because just's shebang dispatch
 # requires `cygpath` on Windows (only on PATH from inside Git Bash),
 # while [script("pwsh")] works from plain PowerShell with no PATH
-# augmentation. The `??` null-coalescing operator used in the splat
-# requires pwsh 7+, which is the floor we already require via
-# _anvil-require pwsh.
+# augmentation. We require pwsh 7+ (enforced via _anvil-require pwsh)
+# for consistent semantics of the array-splat splice and the modern
+# operators used across these recipes.
 #
 # Single-command recipes (cargo deny check, cargo audit) are plain
 # just recipes that inherit the adopter's default shell — they're
@@ -1288,7 +1294,7 @@ anvil-fmt: anvil-fmt-validate-prereqs
 anvil-clippy: anvil-clippy-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo clippy @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --all-targets --all-features --locked "--" '-D' 'warnings'
+    & cargo clippy @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --all-targets --all-features --locked "--" '-D' 'warnings'
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Modified tier.
@@ -1338,7 +1344,7 @@ anvil-doc-build: anvil-doc-build-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_REQUIRED -eq '--skip') { exit 0 }
     $env:RUSTDOCFLAGS = '-D warnings'
-    & cargo doc @(-split ($env:ANVIL_INCLUDE_REQUIRED ?? "--workspace")) --all-features --no-deps
+    & cargo doc @(if ($env:ANVIL_INCLUDE_REQUIRED) { -split $env:ANVIL_INCLUDE_REQUIRED } else { '--workspace' }) --all-features --no-deps
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Modified tier.
@@ -1522,7 +1528,7 @@ anvil-audit: anvil-audit-validate-prereqs
 anvil-udeps: anvil-udeps-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_REQUIRED -eq '--skip') { exit 0 }
-    & cargo '+{{ rust_nightly }}' udeps @(-split ($env:ANVIL_INCLUDE_REQUIRED ?? "--workspace")) --all-features
+    & cargo '+{{ rust_nightly }}' udeps @(if ($env:ANVIL_INCLUDE_REQUIRED) { -split $env:ANVIL_INCLUDE_REQUIRED } else { '--workspace' }) --all-features
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Affected tier (compares published API of changed crates against the
@@ -1852,7 +1858,7 @@ anvil-llvm-cov: anvil-llvm-cov-validate-prereqs
 anvil-doc-test: anvil-doc-test-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    $pkg = @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace"))
+    $pkg = @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' })
     & cargo test --doc @pkg --all-features --locked
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     & cargo test --doc @pkg --locked
@@ -1863,7 +1869,7 @@ anvil-doc-test: anvil-doc-test-validate-prereqs
 anvil-examples: anvil-examples-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo build @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --examples --all-features --locked
+    & cargo build @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --examples --all-features --locked
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # === pr-mutants member ====================================================
@@ -1938,7 +1944,7 @@ anvil-miri: anvil-miri-validate-prereqs
     # empty test runs as success for miri only. Other nextest-using
     # recipes (llvm-cov) keep exit-4 as a failure because zero tests
     # there almost always indicates a config mistake.
-    & cargo '+{{ rust_nightly }}' miri nextest run --no-tests=pass @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace"))
+    & cargo '+{{ rust_nightly }}' miri nextest run --no-tests=pass @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' })
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Stricter miri profiles. Each runs miri over the full workspace
@@ -1997,7 +2003,7 @@ anvil-miri-race-coverage: anvil-miri-race-coverage-validate-prereqs
 anvil-careful: anvil-careful-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo '+{{ rust_nightly }}' careful test @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --all-features --locked
+    & cargo '+{{ rust_nightly }}' careful test @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --all-features --locked
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Affected tier. `loom` is a permutation-based concurrency model
@@ -2093,7 +2099,7 @@ anvil-mutants-full: anvil-mutants-full-validate-prereqs
 anvil-cargo-hack: anvil-cargo-hack-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_REQUIRED -eq '--skip') { exit 0 }
-    & cargo hack @(-split ($env:ANVIL_INCLUDE_REQUIRED ?? "--workspace")) --feature-powerset --depth 2 check
+    & cargo hack @(if ($env:ANVIL_INCLUDE_REQUIRED) { -split $env:ANVIL_INCLUDE_REQUIRED } else { '--workspace' }) --feature-powerset --depth 2 check
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Affected tier.
@@ -2101,7 +2107,7 @@ anvil-cargo-hack: anvil-cargo-hack-validate-prereqs
 anvil-bench: anvil-bench-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo bench @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --all-features --no-run
+    & cargo bench @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --all-features --no-run
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 

--- a/crates/cargo-anvil/tests/snapshots/snapshots__github_backend.snap
+++ b/crates/cargo-anvil/tests/snapshots/snapshots__github_backend.snap
@@ -1276,24 +1276,30 @@ unknown-git = "deny"
 #     here. Scheduled-exhaustive recipes (mutants-full) are also unscoped
 #     by design.
 #
-# Local invocation (no impact wiring): all three env vars are unset
-# (recipes use the `?? "--workspace"` null-coalescing fallback below);
-# modified-tier recipes simply skip the splice and run their
+# Local invocation (no impact wiring): all three env vars are unset or
+# empty (recipes fall back to "--workspace" via the truthiness check
+# below); modified-tier recipes simply skip the splice and run their
 # workspace-wide tool; affected/required-tier recipes splat
-# "--workspace" when the env var is unset.
+# "--workspace" when the env var is empty or unset.
 #
 # Preparation contract: when a recipe reaches the cargo call, the
 # env var is one of:
 #
-#   * unset                       - local run; the recipe substitutes
-#                                    "--workspace" via `?? "--workspace"`
+#   * unset or ""                 - local run, or a cloud workflow (e.g.
+#                                    scheduled) that leaves the tier
+#                                    unscoped; the recipe substitutes
+#                                    "--workspace". An empty string is
+#                                    NOT $null, so we test truthiness
+#                                    rather than `?? "--workspace"`
+#                                    (which would only catch $null and
+#                                    splat an empty arg cargo rejects).
 #   * "--package A --package B"   - emitted by the cloud-workflow impact step when
 #                                    the tier has members
 #   * "--skip"                    - emitted by the cloud-workflow impact step when
 #                                    the tier is empty (recipe exits 0)
 #
 # This lets the simple recipes splat the var directly with
-#   & cargo X @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) ...
+#   & cargo X @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) ...
 # and reduces the per-recipe boilerplate to a single one-line skip
 # guard plus the cargo invocation.
 #
@@ -1307,9 +1313,9 @@ unknown-git = "deny"
 # installer. We chose pwsh over bash because just's shebang dispatch
 # requires `cygpath` on Windows (only on PATH from inside Git Bash),
 # while [script("pwsh")] works from plain PowerShell with no PATH
-# augmentation. The `??` null-coalescing operator used in the splat
-# requires pwsh 7+, which is the floor we already require via
-# _anvil-require pwsh.
+# augmentation. We require pwsh 7+ (enforced via _anvil-require pwsh)
+# for consistent semantics of the array-splat splice and the modern
+# operators used across these recipes.
 #
 # Single-command recipes (cargo deny check, cargo audit) are plain
 # just recipes that inherit the adopter's default shell — they're
@@ -1345,7 +1351,7 @@ anvil-fmt: anvil-fmt-validate-prereqs
 anvil-clippy: anvil-clippy-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo clippy @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --all-targets --all-features --locked "--" '-D' 'warnings'
+    & cargo clippy @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --all-targets --all-features --locked "--" '-D' 'warnings'
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Modified tier.
@@ -1395,7 +1401,7 @@ anvil-doc-build: anvil-doc-build-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_REQUIRED -eq '--skip') { exit 0 }
     $env:RUSTDOCFLAGS = '-D warnings'
-    & cargo doc @(-split ($env:ANVIL_INCLUDE_REQUIRED ?? "--workspace")) --all-features --no-deps
+    & cargo doc @(if ($env:ANVIL_INCLUDE_REQUIRED) { -split $env:ANVIL_INCLUDE_REQUIRED } else { '--workspace' }) --all-features --no-deps
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Modified tier.
@@ -1579,7 +1585,7 @@ anvil-audit: anvil-audit-validate-prereqs
 anvil-udeps: anvil-udeps-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_REQUIRED -eq '--skip') { exit 0 }
-    & cargo '+{{ rust_nightly }}' udeps @(-split ($env:ANVIL_INCLUDE_REQUIRED ?? "--workspace")) --all-features
+    & cargo '+{{ rust_nightly }}' udeps @(if ($env:ANVIL_INCLUDE_REQUIRED) { -split $env:ANVIL_INCLUDE_REQUIRED } else { '--workspace' }) --all-features
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Affected tier (compares published API of changed crates against the
@@ -1909,7 +1915,7 @@ anvil-llvm-cov: anvil-llvm-cov-validate-prereqs
 anvil-doc-test: anvil-doc-test-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    $pkg = @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace"))
+    $pkg = @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' })
     & cargo test --doc @pkg --all-features --locked
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     & cargo test --doc @pkg --locked
@@ -1920,7 +1926,7 @@ anvil-doc-test: anvil-doc-test-validate-prereqs
 anvil-examples: anvil-examples-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo build @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --examples --all-features --locked
+    & cargo build @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --examples --all-features --locked
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # === pr-mutants member ====================================================
@@ -1995,7 +2001,7 @@ anvil-miri: anvil-miri-validate-prereqs
     # empty test runs as success for miri only. Other nextest-using
     # recipes (llvm-cov) keep exit-4 as a failure because zero tests
     # there almost always indicates a config mistake.
-    & cargo '+{{ rust_nightly }}' miri nextest run --no-tests=pass @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace"))
+    & cargo '+{{ rust_nightly }}' miri nextest run --no-tests=pass @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' })
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Stricter miri profiles. Each runs miri over the full workspace
@@ -2054,7 +2060,7 @@ anvil-miri-race-coverage: anvil-miri-race-coverage-validate-prereqs
 anvil-careful: anvil-careful-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo '+{{ rust_nightly }}' careful test @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --all-features --locked
+    & cargo '+{{ rust_nightly }}' careful test @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --all-features --locked
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Affected tier. `loom` is a permutation-based concurrency model
@@ -2150,7 +2156,7 @@ anvil-mutants-full: anvil-mutants-full-validate-prereqs
 anvil-cargo-hack: anvil-cargo-hack-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_REQUIRED -eq '--skip') { exit 0 }
-    & cargo hack @(-split ($env:ANVIL_INCLUDE_REQUIRED ?? "--workspace")) --feature-powerset --depth 2 check
+    & cargo hack @(if ($env:ANVIL_INCLUDE_REQUIRED) { -split $env:ANVIL_INCLUDE_REQUIRED } else { '--workspace' }) --feature-powerset --depth 2 check
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Affected tier.
@@ -2158,7 +2164,7 @@ anvil-cargo-hack: anvil-cargo-hack-validate-prereqs
 anvil-bench: anvil-bench-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo bench @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --all-features --no-run
+    & cargo bench @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --all-features --no-run
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 

--- a/crates/cargo-anvil/tests/snapshots/snapshots__local_only.snap
+++ b/crates/cargo-anvil/tests/snapshots/snapshots__local_only.snap
@@ -227,24 +227,30 @@ unknown-git = "deny"
 #     here. Scheduled-exhaustive recipes (mutants-full) are also unscoped
 #     by design.
 #
-# Local invocation (no impact wiring): all three env vars are unset
-# (recipes use the `?? "--workspace"` null-coalescing fallback below);
-# modified-tier recipes simply skip the splice and run their
+# Local invocation (no impact wiring): all three env vars are unset or
+# empty (recipes fall back to "--workspace" via the truthiness check
+# below); modified-tier recipes simply skip the splice and run their
 # workspace-wide tool; affected/required-tier recipes splat
-# "--workspace" when the env var is unset.
+# "--workspace" when the env var is empty or unset.
 #
 # Preparation contract: when a recipe reaches the cargo call, the
 # env var is one of:
 #
-#   * unset                       - local run; the recipe substitutes
-#                                    "--workspace" via `?? "--workspace"`
+#   * unset or ""                 - local run, or a cloud workflow (e.g.
+#                                    scheduled) that leaves the tier
+#                                    unscoped; the recipe substitutes
+#                                    "--workspace". An empty string is
+#                                    NOT $null, so we test truthiness
+#                                    rather than `?? "--workspace"`
+#                                    (which would only catch $null and
+#                                    splat an empty arg cargo rejects).
 #   * "--package A --package B"   - emitted by the cloud-workflow impact step when
 #                                    the tier has members
 #   * "--skip"                    - emitted by the cloud-workflow impact step when
 #                                    the tier is empty (recipe exits 0)
 #
 # This lets the simple recipes splat the var directly with
-#   & cargo X @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) ...
+#   & cargo X @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) ...
 # and reduces the per-recipe boilerplate to a single one-line skip
 # guard plus the cargo invocation.
 #
@@ -258,9 +264,9 @@ unknown-git = "deny"
 # installer. We chose pwsh over bash because just's shebang dispatch
 # requires `cygpath` on Windows (only on PATH from inside Git Bash),
 # while [script("pwsh")] works from plain PowerShell with no PATH
-# augmentation. The `??` null-coalescing operator used in the splat
-# requires pwsh 7+, which is the floor we already require via
-# _anvil-require pwsh.
+# augmentation. We require pwsh 7+ (enforced via _anvil-require pwsh)
+# for consistent semantics of the array-splat splice and the modern
+# operators used across these recipes.
 #
 # Single-command recipes (cargo deny check, cargo audit) are plain
 # just recipes that inherit the adopter's default shell — they're
@@ -296,7 +302,7 @@ anvil-fmt: anvil-fmt-validate-prereqs
 anvil-clippy: anvil-clippy-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo clippy @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --all-targets --all-features --locked "--" '-D' 'warnings'
+    & cargo clippy @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --all-targets --all-features --locked "--" '-D' 'warnings'
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Modified tier.
@@ -346,7 +352,7 @@ anvil-doc-build: anvil-doc-build-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_REQUIRED -eq '--skip') { exit 0 }
     $env:RUSTDOCFLAGS = '-D warnings'
-    & cargo doc @(-split ($env:ANVIL_INCLUDE_REQUIRED ?? "--workspace")) --all-features --no-deps
+    & cargo doc @(if ($env:ANVIL_INCLUDE_REQUIRED) { -split $env:ANVIL_INCLUDE_REQUIRED } else { '--workspace' }) --all-features --no-deps
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Modified tier.
@@ -530,7 +536,7 @@ anvil-audit: anvil-audit-validate-prereqs
 anvil-udeps: anvil-udeps-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_REQUIRED -eq '--skip') { exit 0 }
-    & cargo '+{{ rust_nightly }}' udeps @(-split ($env:ANVIL_INCLUDE_REQUIRED ?? "--workspace")) --all-features
+    & cargo '+{{ rust_nightly }}' udeps @(if ($env:ANVIL_INCLUDE_REQUIRED) { -split $env:ANVIL_INCLUDE_REQUIRED } else { '--workspace' }) --all-features
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Affected tier (compares published API of changed crates against the
@@ -860,7 +866,7 @@ anvil-llvm-cov: anvil-llvm-cov-validate-prereqs
 anvil-doc-test: anvil-doc-test-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    $pkg = @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace"))
+    $pkg = @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' })
     & cargo test --doc @pkg --all-features --locked
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     & cargo test --doc @pkg --locked
@@ -871,7 +877,7 @@ anvil-doc-test: anvil-doc-test-validate-prereqs
 anvil-examples: anvil-examples-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo build @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --examples --all-features --locked
+    & cargo build @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --examples --all-features --locked
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # === pr-mutants member ====================================================
@@ -946,7 +952,7 @@ anvil-miri: anvil-miri-validate-prereqs
     # empty test runs as success for miri only. Other nextest-using
     # recipes (llvm-cov) keep exit-4 as a failure because zero tests
     # there almost always indicates a config mistake.
-    & cargo '+{{ rust_nightly }}' miri nextest run --no-tests=pass @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace"))
+    & cargo '+{{ rust_nightly }}' miri nextest run --no-tests=pass @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' })
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Stricter miri profiles. Each runs miri over the full workspace
@@ -1005,7 +1011,7 @@ anvil-miri-race-coverage: anvil-miri-race-coverage-validate-prereqs
 anvil-careful: anvil-careful-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo '+{{ rust_nightly }}' careful test @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --all-features --locked
+    & cargo '+{{ rust_nightly }}' careful test @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --all-features --locked
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Affected tier. `loom` is a permutation-based concurrency model
@@ -1101,7 +1107,7 @@ anvil-mutants-full: anvil-mutants-full-validate-prereqs
 anvil-cargo-hack: anvil-cargo-hack-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_REQUIRED -eq '--skip') { exit 0 }
-    & cargo hack @(-split ($env:ANVIL_INCLUDE_REQUIRED ?? "--workspace")) --feature-powerset --depth 2 check
+    & cargo hack @(if ($env:ANVIL_INCLUDE_REQUIRED) { -split $env:ANVIL_INCLUDE_REQUIRED } else { '--workspace' }) --feature-powerset --depth 2 check
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Affected tier.
@@ -1109,7 +1115,7 @@ anvil-cargo-hack: anvil-cargo-hack-validate-prereqs
 anvil-bench: anvil-bench-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo bench @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --all-features --no-run
+    & cargo bench @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --all-features --no-run
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 

--- a/justfiles/anvil/checks.just
+++ b/justfiles/anvil/checks.just
@@ -30,24 +30,30 @@
 #     here. Scheduled-exhaustive recipes (mutants-full) are also unscoped
 #     by design.
 #
-# Local invocation (no impact wiring): all three env vars are unset
-# (recipes use the `?? "--workspace"` null-coalescing fallback below);
-# modified-tier recipes simply skip the splice and run their
+# Local invocation (no impact wiring): all three env vars are unset or
+# empty (recipes fall back to "--workspace" via the truthiness check
+# below); modified-tier recipes simply skip the splice and run their
 # workspace-wide tool; affected/required-tier recipes splat
-# "--workspace" when the env var is unset.
+# "--workspace" when the env var is empty or unset.
 #
 # Preparation contract: when a recipe reaches the cargo call, the
 # env var is one of:
 #
-#   * unset                       - local run; the recipe substitutes
-#                                    "--workspace" via `?? "--workspace"`
+#   * unset or ""                 - local run, or a cloud workflow (e.g.
+#                                    scheduled) that leaves the tier
+#                                    unscoped; the recipe substitutes
+#                                    "--workspace". An empty string is
+#                                    NOT $null, so we test truthiness
+#                                    rather than `?? "--workspace"`
+#                                    (which would only catch $null and
+#                                    splat an empty arg cargo rejects).
 #   * "--package A --package B"   - emitted by the cloud-workflow impact step when
 #                                    the tier has members
 #   * "--skip"                    - emitted by the cloud-workflow impact step when
 #                                    the tier is empty (recipe exits 0)
 #
 # This lets the simple recipes splat the var directly with
-#   & cargo X @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) ...
+#   & cargo X @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) ...
 # and reduces the per-recipe boilerplate to a single one-line skip
 # guard plus the cargo invocation.
 #
@@ -61,9 +67,9 @@
 # installer. We chose pwsh over bash because just's shebang dispatch
 # requires `cygpath` on Windows (only on PATH from inside Git Bash),
 # while [script("pwsh")] works from plain PowerShell with no PATH
-# augmentation. The `??` null-coalescing operator used in the splat
-# requires pwsh 7+, which is the floor we already require via
-# _anvil-require pwsh.
+# augmentation. We require pwsh 7+ (enforced via _anvil-require pwsh)
+# for consistent semantics of the array-splat splice and the modern
+# operators used across these recipes.
 #
 # Single-command recipes (cargo deny check, cargo audit) are plain
 # just recipes that inherit the adopter's default shell — they're
@@ -99,7 +105,7 @@ anvil-fmt: anvil-fmt-validate-prereqs
 anvil-clippy: anvil-clippy-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo clippy @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --all-targets --all-features --locked "--" '-D' 'warnings'
+    & cargo clippy @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --all-targets --all-features --locked "--" '-D' 'warnings'
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Modified tier.
@@ -149,7 +155,7 @@ anvil-doc-build: anvil-doc-build-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_REQUIRED -eq '--skip') { exit 0 }
     $env:RUSTDOCFLAGS = '-D warnings'
-    & cargo doc @(-split ($env:ANVIL_INCLUDE_REQUIRED ?? "--workspace")) --all-features --no-deps
+    & cargo doc @(if ($env:ANVIL_INCLUDE_REQUIRED) { -split $env:ANVIL_INCLUDE_REQUIRED } else { '--workspace' }) --all-features --no-deps
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Modified tier.
@@ -333,7 +339,7 @@ anvil-audit: anvil-audit-validate-prereqs
 anvil-udeps: anvil-udeps-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_REQUIRED -eq '--skip') { exit 0 }
-    & cargo '+{{ rust_nightly }}' udeps @(-split ($env:ANVIL_INCLUDE_REQUIRED ?? "--workspace")) --all-features
+    & cargo '+{{ rust_nightly }}' udeps @(if ($env:ANVIL_INCLUDE_REQUIRED) { -split $env:ANVIL_INCLUDE_REQUIRED } else { '--workspace' }) --all-features
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Affected tier (compares published API of changed crates against the
@@ -663,7 +669,7 @@ anvil-llvm-cov: anvil-llvm-cov-validate-prereqs
 anvil-doc-test: anvil-doc-test-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    $pkg = @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace"))
+    $pkg = @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' })
     & cargo test --doc @pkg --all-features --locked
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     & cargo test --doc @pkg --locked
@@ -674,7 +680,7 @@ anvil-doc-test: anvil-doc-test-validate-prereqs
 anvil-examples: anvil-examples-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo build @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --examples --all-features --locked
+    & cargo build @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --examples --all-features --locked
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # === pr-mutants member ====================================================
@@ -749,7 +755,7 @@ anvil-miri: anvil-miri-validate-prereqs
     # empty test runs as success for miri only. Other nextest-using
     # recipes (llvm-cov) keep exit-4 as a failure because zero tests
     # there almost always indicates a config mistake.
-    & cargo '+{{ rust_nightly }}' miri nextest run --no-tests=pass @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace"))
+    & cargo '+{{ rust_nightly }}' miri nextest run --no-tests=pass @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' })
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Stricter miri profiles. Each runs miri over the full workspace
@@ -808,7 +814,7 @@ anvil-miri-race-coverage: anvil-miri-race-coverage-validate-prereqs
 anvil-careful: anvil-careful-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo '+{{ rust_nightly }}' careful test @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --all-features --locked
+    & cargo '+{{ rust_nightly }}' careful test @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --all-features --locked
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Affected tier. `loom` is a permutation-based concurrency model
@@ -904,7 +910,7 @@ anvil-mutants-full: anvil-mutants-full-validate-prereqs
 anvil-cargo-hack: anvil-cargo-hack-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_REQUIRED -eq '--skip') { exit 0 }
-    & cargo hack @(-split ($env:ANVIL_INCLUDE_REQUIRED ?? "--workspace")) --feature-powerset --depth 2 check
+    & cargo hack @(if ($env:ANVIL_INCLUDE_REQUIRED) { -split $env:ANVIL_INCLUDE_REQUIRED } else { '--workspace' }) --feature-powerset --depth 2 check
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Affected tier.
@@ -912,7 +918,7 @@ anvil-cargo-hack: anvil-cargo-hack-validate-prereqs
 anvil-bench: anvil-bench-validate-prereqs
     $ErrorActionPreference = 'Stop'
     if ($env:ANVIL_INCLUDE_AFFECTED -eq '--skip') { exit 0 }
-    & cargo bench @(-split ($env:ANVIL_INCLUDE_AFFECTED ?? "--workspace")) --all-features --no-run
+    & cargo bench @(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' }) --all-features --no-run
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 


### PR DESCRIPTION
## Summary

The scheduled `anvil-scheduled` workflow has been failing on every job with:

```
error: unexpected argument '' found
```

### Root cause

The anvil check recipes substituted `--workspace` only when the `ANVIL_INCLUDE_*`
env vars were `$null`, via `?? "--workspace"`. In cloud workflows the composite
action sets these to an **empty string** (its input `default: ""`) whenever a tier
isn't impact-scoped — which is exactly what the scheduled workflow does. An empty
string is not `$null`, so the `??` fallback never fired and `-split ""` splatted a
single empty argument that cargo rejects, failing every scheduled job.

Local runs were unaffected because the env var is genuinely unset (`$null`) there,
so `??` worked.

### Fix

Switch the nine fallback sites to the truthiness form already used by the
per-package recipes, which treats both `$null` and `""` as empty:

```powershell
@(if ($env:ANVIL_INCLUDE_AFFECTED) { -split $env:ANVIL_INCLUDE_AFFECTED } else { '--workspace' })
```

The header preparation-contract docs are updated to explain why truthiness is used
over `??`. The in-tree justfile, insta snapshots, and `.anvil.lock` are regenerated
via `cargo anvil`.

### Verification

- `cargo test -p cargo-anvil --test snapshots` — passes.
- `cargo anvil --dry-run` — `Unchanged` (regenerate-check gate passes).

### Notes

- Stacked on top of `add-more-tools-to-anvil`; retarget to `main` once that lands.
- All edits are in the cargo-anvil template (`crates/cargo-anvil/templates/justfiles/anvil/checks.just`);
  the generated files are regenerated output.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
